### PR TITLE
Updates Dockerfile to install latest tar

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apk --no-cache add -f \
     curl \
     socat \
     tini \
+    tar \
     && \
     curl -sSL https://github.com/acmesh-official/acme.sh/archive/${VERSION}.tar.gz | tar xz --strip-components=1 && \
     chmod 755 ./acme.sh && \


### PR DESCRIPTION
I've found that this fails to copy the files via docker sock as the existing `tar` is just the "BusyBox v1.31.1 () multi-call binary." so it doesn't understand the `--transform` parameter required by acme.sh (as shown [here](https://github.com/acmesh-official/acme.sh/blob/421973e0d911662e2f3036c03123d567cc5c3638/deploy/docker.sh#L228))

This will ensure that `tar` gets installed and updated to the correct version, thus making everything work correctly!